### PR TITLE
feat: add GitHub Actions CI pipeline for Rust project

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI for book
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths-ignore:
+      - "README.md"
+      - "frontend/**"
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable
+      - name: Install cargo-related tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest,cargo-make
+      - name: Tests compile
+        run: cargo make test-ci --no-run --locked
+      - name: Test
+        run: cargo make test-ci
+      - name: Clippy
+        run: cargo make clippy-ci -- -Dwarnings
+      - name: Rustfmt
+        run: cargo make fmt -- --check


### PR DESCRIPTION
- プッシュ時およびプルリクエスト時にCIを実行するワークフローを追加
- `main`ブランチへのプッシュと特定のパスに関係しないプルリクエストでトリガー
- Ubuntu環境でRustのツールチェーンおよび各種ツールをインストール
- テスト、Clippy、Rustfmtのチェックを含むパイプラインを構成